### PR TITLE
Use ~ to import vuetify from node_modules

### DIFF
--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -89,6 +89,6 @@
 </script>
 
 <style lang="stylus">
-  @import '../node_modules/vuetify/src/stylus/main'
+  @import '~vuetify/src/stylus/main'
   @import './css/main.css'
 </style>


### PR DESCRIPTION
I have not tested this with the template, only in my project, but it should work.

See https://github.com/shama/stylus-loader#usage